### PR TITLE
Clean experiment end, one click start

### DIFF
--- a/lightsheet/gui/main_gui.py
+++ b/lightsheet/gui/main_gui.py
@@ -106,12 +106,13 @@ class MainWindow(QMainWindow):
 
     def check_end_experiment(self):
         if self.st.saver.saver_stopped_signal.is_set():
-            self.st.end_experiment()
-            self.st.saver.saver_stopped_signal.clear()
+            self.st.toggle_experiment_state()
             if self.st.pause_after:
                 self.wid_status.setCurrentIndex(0)
                 self.st.laser.set_current(0)
-                self.refresh_param_values()
+            self.refresh_param_values()
+            self.wid_display.experiment_progress.hide()
+            self.st.saver.saver_stopped_signal.clear()
 
 
 class StatusWidget(QTabWidget):

--- a/lightsheet/gui/scanning_gui.py
+++ b/lightsheet/gui/scanning_gui.py
@@ -23,9 +23,8 @@ class PlanarScanningWidget(QWidget):
 
 STATE_TEXTS = {
     ExperimentPrepareState.NO_TRIGGER: "Start recording",
-    ExperimentPrepareState.PREVIEW: "Prepare recording",
+    ExperimentPrepareState.PREVIEW: "Start recording",
     ExperimentPrepareState.EXPERIMENT_STARTED: "Recording started. Press to abort",
-    ExperimentPrepareState.ABORT: "Experiment aborted"
 }
 
 
@@ -49,7 +48,7 @@ class VolumeScanningWidget(QWidget):
         self.wid_volume = ParameterGui(state.volume_setting)
         self.btn_start = QPushButton()
         self.btn_start.setCheckable(True)
-        self.btn_start.clicked.connect(self.state.toggle_experiment_state)
+        self.btn_start.clicked.connect(self.change_experiment_state)
         self.chk_pause = QCheckBox("Pause after experiment")
 
         self.wid_alignment = ParameterGui(self.state.scope_alignment_info)
@@ -79,10 +78,11 @@ class VolumeScanningWidget(QWidget):
         self.timer_scope_info.timeout.connect(self.update_alignment)
         self.chk_pause.clicked.connect(self.change_pause_status)
 
+        self.chk_pause.click()
+
     def updateBtnText(self):
         self.btn_start.setText(STATE_TEXTS[self.state.experiment_state])
-        if self.state.experiment_state == ExperimentPrepareState.PREVIEW or \
-                self.state.experiment_state == ExperimentPrepareState.ABORT:
+        if self.state.experiment_state == ExperimentPrepareState.PREVIEW:
             self.btn_start.setChecked(False)
         if self.state.experiment_state == ExperimentPrepareState.NO_TRIGGER or \
                 self.state.experiment_state == ExperimentPrepareState.EXPERIMENT_STARTED:
@@ -104,3 +104,10 @@ class VolumeScanningWidget(QWidget):
 
     def change_pause_status(self):
         self.state.pause_after = self.chk_pause.isChecked()
+
+    def change_experiment_state(self):
+        if self.state.experiment_state == ExperimentPrepareState.EXPERIMENT_STARTED:
+            # Here what happens if experiment is aborted
+            self.state.saver.saving_signal.clear()
+        else:
+            self.state.toggle_experiment_state()

--- a/lightsheet/state.py
+++ b/lightsheet/state.py
@@ -431,30 +431,27 @@ class State:
     def toggle_experiment_state(self):
         if self.experiment_state == ExperimentPrepareState.PREVIEW:
             self.experiment_state = ExperimentPrepareState.NO_TRIGGER
-            self.prepare_experiment()
+            self.start_experiment()
 
         elif self.experiment_state == ExperimentPrepareState.NO_TRIGGER:
             self.experiment_state = ExperimentPrepareState.EXPERIMENT_STARTED
             self.send_scan_settings()
 
         elif self.experiment_state == ExperimentPrepareState.EXPERIMENT_STARTED:
-            self.experiment_state = ExperimentPrepareState.ABORT
-            self.abort_experiment()
             self.experiment_state = ExperimentPrepareState.PREVIEW
-            self.send_scan_settings()
+            self.end_experiment()
 
-    def prepare_experiment(self):
-        # TODO disable the GUI
+    def start_experiment(self):
+        # TODO disable the GUI except the abort button
         self.send_scan_settings()
         self.saver.saving_signal.set()
-
-    def abort_experiment(self):
-        self.end_experiment()
+        self.saver.save_queue.empty()
+        self.camera.image_queue.empty()
+        self.toggle_experiment_state()
 
     def end_experiment(self):
         self.saver.saving_signal.clear()
         self.experiment_start_event.clear()
-        self.saver.saver_stopped_signal.clear()
         self.saver.save_queue.clear()
         self.send_scan_settings()
 

--- a/lightsheet/streaming_save.py
+++ b/lightsheet/streaming_save.py
@@ -101,7 +101,7 @@ class StackSaver(Process):
             self.update_saved_status_queue()
             self.finalize_dataset()
             self.current_data = None
-            if self.save_parameters.notification_email != "None":
+            if self.save_parameters.notification_email != "None" and self.saving_signal.is_set():
                 self.send_email_end()
 
         self.saving_signal.clear()
@@ -120,9 +120,8 @@ class StackSaver(Process):
         body = [
             "Hey!",
             "\n",
-            "Your lightsheet experiment has completed and was a success! Come pick up your little fish",
+            "Your lightsheet experiment has finished and was a success! Come pick up your little fish",
             "\n"
-            "Always yours,",
             "fishgitbot"
         ]
 


### PR DESCRIPTION
This PR brings the following improvements:

- Pause after experiment by default
- Start experiment in one click
- Fixed bug in experiment start button after successful experiment ( closes #38 )
- Email notification is not sent if experiment was aborted ( closes #36 )