### PR TITLE
Fixed roi set and restore

### DIFF
--- a/sashimi/camera.py
+++ b/sashimi/camera.py
@@ -243,7 +243,7 @@ class MockCameraProcess(Process):
         # this can be simplified by making the API nice
 
         # This is not sent to the camera but has to be updated with camera info directly (because of multiples of 4)
-        self.parameters.frame_shape = (subarray[2], subarray[3])
+        self.parameters.frame_shape = (subarray[2] // self.parameters.binning, subarray[3] // self.parameters.binning)
 
     def close_camera(self):
         pass

--- a/sashimi/gui/camera_gui.py
+++ b/sashimi/gui/camera_gui.py
@@ -168,6 +168,17 @@ class CameraSettingsContainerWidget(QWidget):
         )
         self.camera_info_timer.timeout.connect(self.update_camera_info)
 
+    def reshape_roi(self):
+        subarray = self.state.camera_settings.subarray
+        self.roi.data = np.array(
+            [
+                [subarray[1], subarray[0]],
+                [subarray[1] + subarray[3], subarray[0]],
+                [subarray[1] + subarray[3], subarray[0] + subarray[2]],
+                [subarray[1], subarray[0] + subarray[2]]
+            ]
+        )
+
     def set_roi(self):
         roi_pos = (int(self.roi.data[0][0][1]), int(self.roi.data[0][0][0]))
         roi_size = (
@@ -175,8 +186,9 @@ class CameraSettingsContainerWidget(QWidget):
             int(self.roi.data[0][1][0] - self.roi.data[0][0][0]),
         )
         self.state.camera_settings.subarray = tuple(
-            [roi_pos[0], roi_pos[1], roi_size[0], roi_size[1]]
+            [roi_pos[1], roi_pos[0], roi_size[1], roi_size[0]]
         )
+        print(self.state.camera_settings.subarray)
         self.update_roi_info(width=roi_size[0], height=roi_size[1])
 
     def set_full_size_frame(self):

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -101,6 +101,7 @@ class MainWindow(QMainWindow):
         self.wid_display.wid_display_settings.refresh_widgets()
         if not omit_wid_camera:
             self.wid_camera.wid_camera_settings.refresh_widgets()
+            self.wid_camera.reshape_roi()
             self.wid_camera.set_roi()
         self.wid_save_options.wid_save_options.refresh_widgets()
         self.wid_save_options.set_locationbutton()

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -45,7 +45,7 @@ class MainWindow(QMainWindow):
         )
         self.wid_scan = PlanarScanningWidget(st)
         self.wid_camera = CameraSettingsContainerWidget(
-            st, self.wid_display.roi, self.timer
+            st, self.wid_display, self.timer
         )
 
         self.setCentralWidget(self.wid_display)


### PR DESCRIPTION
- Should restore ROI correctly after software reboot.
- 1 button only to select ROI.

~~Running it in my laptop I had the impression ROI was not setup correctly (?) will have to be tested with a fish in the scope.~~ This was a problem of the Fake Camera, also solved

Also, when in full-frame mode the image layer cannot be moved (made bigger/smaller) and I couldn't fix this. This should be solved before merging this PR

close #10 