### PR TITLE
Sashimi option for LFM added with --shirashi option

### DIFF
--- a/sashimi/__init__.py
+++ b/sashimi/__init__.py
@@ -4,4 +4,4 @@ from sashimi.main import main
 
 
 if __name__ == "__main__":
-    main([])
+    main(["--chirashi"])

--- a/sashimi/camera.py
+++ b/sashimi/camera.py
@@ -92,6 +92,7 @@ class CameraProcess(Process):
         self.new_parameters = copy(self.parameters)
         self.camera_status_queue = Queue()
         self.triggered_frame_rate_queue = Queue()
+        self.triggered_frame_rate_queue_copy = Queue()
         self.framerate_rec = FramerateRecorder(n_fps_frames=n_fps_frames)
 
     def cast_parameters(self):
@@ -156,6 +157,7 @@ class CameraProcess(Process):
         self.framerate_rec.update_framerate()
         if self.framerate_rec.i_fps == 0:
             self.triggered_frame_rate_queue.put(self.framerate_rec.current_framerate)
+            self.triggered_frame_rate_queue_copy.put(self.framerate_rec.current_framerate)
 
     # TODO: Move this to API
     def apply_parameters(self):

--- a/sashimi/config.py
+++ b/sashimi/config.py
@@ -27,7 +27,7 @@ TEMPLATE_CONF_DICT = {
     "email": {"user": "foo", "password": "foo"},
     "array_ram_MB": 450,
     "scopeless": False,
-    "shirashi": False,
+    "chirashi": False,
 }
 
 

--- a/sashimi/config.py
+++ b/sashimi/config.py
@@ -27,6 +27,7 @@ TEMPLATE_CONF_DICT = {
     "email": {"user": "foo", "password": "foo"},
     "array_ram_MB": 450,
     "scopeless": False,
+    "shirashi": False,
 }
 
 

--- a/sashimi/gui/scanning_gui.py
+++ b/sashimi/gui/scanning_gui.py
@@ -22,6 +22,7 @@ class PlanarScanningWidget(QWidget):
         self.layout().addWidget(self.wid_planar)
 
 
+
 STATE_TEXTS = {
     ExperimentPrepareState.NO_TRIGGER: "Start recording",
     ExperimentPrepareState.PREVIEW: "Start recording",
@@ -36,6 +37,63 @@ class SinglePlaneScanningWidget(QWidget):
         self.setLayout(QVBoxLayout())
         self.wid_singleplane = ParameterGui(state.single_plane_settings)
         self.layout().addWidget(self.wid_singleplane)
+
+        self.btn_start = QPushButton()
+        self.btn_start.setCheckable(True)
+        self.btn_start.clicked.connect(self.change_experiment_state)
+        self.chk_pause = QCheckBox("Pause after experiment")
+
+        self.dialog_box = QMessageBox()
+        self.dialog_ok_button = self.dialog_box.addButton(self.dialog_box.Ok)
+        self.dialog_abort_button = self.dialog_box.addButton(self.dialog_box.Abort)
+        self.override_overwrite = False
+
+        self.layout().addWidget(self.btn_start)
+        self.layout().addWidget(self.chk_pause)
+
+        self.updateBtnText()
+        self.chk_pause.clicked.connect(self.change_pause_status)
+        self.dialog_ok_button.clicked.connect(self.overwrite_anyway)
+        self.chk_pause.click()
+
+    def updateBtnText(self):
+        self.btn_start.setText(STATE_TEXTS[self.state.experiment_state])
+        if self.state.experiment_state == ExperimentPrepareState.PREVIEW:
+            self.btn_start.setChecked(False)
+        if (
+                self.state.experiment_state == ExperimentPrepareState.NO_TRIGGER
+                or self.state.experiment_state == ExperimentPrepareState.EXPERIMENT_STARTED
+        ):
+            self.btn_start.setChecked(True)
+
+    def change_pause_status(self):
+        self.state.pause_after = self.chk_pause.isChecked()
+
+    def change_experiment_state(self):
+        if self.state.experiment_state == ExperimentPrepareState.EXPERIMENT_STARTED:
+            # Here what happens if experiment is aborted
+            self.state.saver.saving_signal.clear()
+        elif (
+                self.state.save_settings.overwrite_save_folder == 1
+                and not self.override_overwrite
+        ):
+            self.overwrite_alert_popup()
+            self.override_overwrite = False
+        else:
+            self.state.toggle_experiment_state()
+
+    def overwrite_alert_popup(self):
+        self.dialog_box.setIcon(QMessageBox.Warning)
+        self.dialog_box.setWindowTitle("Overwrite alert!")
+        self.dialog_box.setText(
+            "You are overwriting an existing folder with data. \n\n "
+            "Press ok to start the experiment anyway or abort to change saving folder."
+        )
+        self.dialog_box.show()
+
+    def overwrite_anyway(self):
+        self.override_overwrite = True
+        self.change_experiment_state()
 
 
 class VolumeScanningWidget(QWidget):

--- a/sashimi/hardware/laser.py
+++ b/sashimi/hardware/laser.py
@@ -2,8 +2,8 @@ from warnings import warn
 
 try:
     import visa
-
-    rm = visa.ResourceManager()
+    from pyvisa.highlevel import ResourceManager
+    rm = ResourceManager()
 except (ImportError, ValueError):
     warn("PyVisa not installed, no laser control available")
 

--- a/sashimi/main.py
+++ b/sashimi/main.py
@@ -10,11 +10,16 @@ from sashimi.state import State
 @click.command()
 @click.option("--sample-rate", default=40000, help="")
 @click.option("--scopeless", is_flag=True, help="")
+@click.option("--shirashi", is_flag=True, help="")
 def main(sample_rate, scopeless):
     if scopeless:
         _cli_modify_config("edit", "scopeless", True)
     else:
         _cli_modify_config("edit", "scopeless", False)
+    if scopeless:
+        _cli_modify_config("edit", "shirashi", True)
+    else:
+        _cli_modify_config("edit", "shirashi", False)
     app = QApplication([])
     app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
     app.setApplicationName("Sashimi")

--- a/sashimi/main.py
+++ b/sashimi/main.py
@@ -10,16 +10,16 @@ from sashimi.state import State
 @click.command()
 @click.option("--sample-rate", default=40000, help="")
 @click.option("--scopeless", is_flag=True, help="")
-@click.option("--shirashi", is_flag=True, help="")
-def main(sample_rate, scopeless):
+@click.option("--chirashi", is_flag=True, help="")
+def main(sample_rate, scopeless, chirashi):
     if scopeless:
         _cli_modify_config("edit", "scopeless", True)
     else:
         _cli_modify_config("edit", "scopeless", False)
-    if scopeless:
-        _cli_modify_config("edit", "shirashi", True)
+    if chirashi:
+        _cli_modify_config("edit", "chirashi", True)
     else:
-        _cli_modify_config("edit", "shirashi", False)
+        _cli_modify_config("edit", "chirashi", False)
     app = QApplication([])
     app.setStyleSheet(qdarkstyle.load_stylesheet_pyqt5())
     app.setApplicationName("Sashimi")

--- a/sashimi/scanning.py
+++ b/sashimi/scanning.py
@@ -490,3 +490,38 @@ class Scanner(Process):
                 self.parameters = deepcopy(
                     scanloop.parameters
                 )  # set the parameters to the last ones received in the loop
+
+
+
+
+class MockScanner(Process):
+    def __init__(
+        self,
+        stop_event: Event,
+        experiment_start_event,
+        n_samples_waveform=10000,
+        sample_rate=40000,
+    ):
+        super().__init__()
+
+        self.stop_event = stop_event
+        self.experiment_start_event = experiment_start_event
+        self.wait_signal = Event()
+
+        self.parameter_queue = Queue()
+
+        self.waveform_queue = ArrayQueue(max_mbytes=100)
+        self.n_samples = n_samples_waveform
+        self.sample_rate = sample_rate
+
+        self.parameters = ScanParameters()
+
+    def setup_tasks(self, read_task, write_task_z, write_task_xy):
+        # Configure the channels
+        pass
+
+    def retrieve_parameters(self):
+        pass
+
+    def run(self):
+        pass

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -339,7 +339,7 @@ class State:
         self.status = ScanningSettings()
         self.scope_alignment_info = ScopeAlignmentInfo()
 
-        if self.conf["shirashi"]:
+        if self.conf["chirashi"]:
             self.camera = CameraProcess(
                         experiment_start_event=self.experiment_start_event,
                         stop_event=self.stop_event,
@@ -465,7 +465,7 @@ class State:
         camera_params = convert_camera_params(self.camera_settings)
         camera_params.trigger_mode = (
             TriggerMode.FREE
-            if self.global_state == GlobalState.PREVIEW or self.conf["shirashi"] #i added this otherwise during volume aqisition no live image and image saving
+            if self.global_state == GlobalState.PREVIEW or self.conf["chirashi"] #i added this otherwise during volume aqisition no live image and image saving
             else TriggerMode.EXTERNAL_TRIGGER
         )
         if self.global_state == GlobalState.PAUSED:
@@ -542,7 +542,7 @@ class State:
 
         elif self.experiment_state == ExperimentPrepareState.NO_TRIGGER:
             self.experiment_state = ExperimentPrepareState.EXPERIMENT_STARTED
-            if self.conf["shirashi"]:#i added this, LS the scanning module sets the event, needed for synch with stytra
+            if self.conf["chirashi"]:#i added this, LS the scanning module sets the event, needed for synch with stytra
                 self.experiment_start_event.set()
             self.send_scan_settings()
 

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -106,7 +106,7 @@ class SinglePlaneSettings(ParametrizedQt):
         self.name = "scanning/z_single_plane"
         self.piezo = Param(200.0, (0.0, 400.0), unit="um", gui="slider")
         self.frequency = Param(1.0, (0.1, 1000), unit="planes/s (Hz)")
-
+        self.n_planes = Param(1, (1, 1))
 
 class ZRecordingSettings(ParametrizedQt):
     def __init__(self):
@@ -114,7 +114,7 @@ class ZRecordingSettings(ParametrizedQt):
         self.name = "scanning/volumetric_recording"
         self.scan_range = Param((0.0, 100.0), (0.0, 400.0), unit="um")
         self.frequency = Param(1.0, (0.1, 100), unit="volumes/s (Hz)")
-        self.n_planes = Param(10, (2, 100))
+        self.n_planes = Param(10, (1, 100)) #todo changed this
         self.n_skip_start = Param(0, (0, 20))
         self.n_skip_end = Param(0, (0, 20))
 
@@ -128,6 +128,7 @@ class CameraSettings(ParametrizedQt):
         self.subarray = Param(
             [0, 0, 2048, 2048], gui=False
         )  # order of params here is [hpos, vpos, hsize, vsize,]
+
 
 
 class LaserSettings(ParametrizedQt):
@@ -394,7 +395,7 @@ class State:
         self.save_status: Optional[SavingStatus] = None
 
         self.saver = StackSaver(
-            stop_event=self.stop_event, duration_queue=self.stytra_comm.duration_queue,
+            stop_event=self.stop_event, duration_queue=self.stytra_comm.duration_queue, triggered_frame_rate_queue_copy=self.camera.triggered_frame_rate_queue_copy
         )
 
         self.dispatcher = VolumeDispatcher(

--- a/sashimi/streaming_save.py
+++ b/sashimi/streaming_save.py
@@ -11,7 +11,7 @@ from arrayqueues.shared_arrays import ArrayQueue
 import yagmail
 from sashimi.config import read_config
 conf = read_config()
-
+import datetime
 
 @dataclass
 class SavingParameters:
@@ -80,6 +80,7 @@ class StackSaver(Process):
         self.i_chunk = 0
         self.i_volume = 0
         self.current_data = None
+        start = datetime.datetime.now()
 
         while (
                 self.i_volume < self.save_parameters.n_volumes
@@ -101,7 +102,7 @@ class StackSaver(Process):
             self.finalize_dataset()
             self.current_data = None
             if self.saving_signal.is_set():
-                print("Done")
+                print("Done: ", datetime.datetime.now() - start)
                     # self.send_email_end()
 
         self.saving_signal.clear()
@@ -220,12 +221,12 @@ class StackSaver(Process):
             pass
         try:
             new_duration = self.duration_queue.get(timeout=0.001)
-            if self.conf["chirashi"]:
-                self.save_parameters.n_volumes = int(round(
-                    np.ceil(int(self.frame_rate) * new_duration)))
-            else:
-                self.save_parameters.n_volumes = int(
-                    np.ceil(self.save_parameters.volumerate * new_duration)
-                )
+            # if self.conf["chirashi"]:
+            #     self.save_parameters.n_volumes = int(round(
+            #         np.ceil(int(self.frame_rate) * new_duration)))
+            # else:
+            self.save_parameters.n_volumes = int(
+                np.ceil(self.save_parameters.volumerate * new_duration)
+            )
         except Empty:
             pass

--- a/sashimi/stytra_comm.py
+++ b/sashimi/stytra_comm.py
@@ -3,7 +3,7 @@ from queue import Empty
 import zmq
 from dataclasses import asdict, is_dataclass
 from enum import Enum
-
+import datetime
 
 def clean_json(d):
     if isinstance(d, dict):
@@ -24,7 +24,8 @@ class StytraCom(Process):
         self,
         stop_event: Event,
         experiment_start_event: Event,
-        stytra_address="tcp://O1-589:5555",
+        stytra_address="tcp://LM-114:5555",
+
     ):
         super().__init__()
         self.current_settings_queue = Queue()
@@ -59,3 +60,4 @@ class StytraCom(Process):
                     self.start_stytra.clear()
                     zmq_socket.close()
                     zmq_context.destroy()
+


### PR DESCRIPTION
Option for operating sashimi without laser or scanning added to support light field acquisition. Reworked config file creation and options to call in main.py as well as the state to work around enabling some functionalities for saving and triggering of stytra protocols.

For running the option:

sashimi --shirashi
