### PR TITLE
Stage motors widget for LFM

### DIFF
--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -13,6 +13,7 @@ from sashimi.gui.save_gui import SaveWidget
 from sashimi.gui.status_bar import StatusBarWidget
 from sashimi.gui.top_bar import TopWidget
 from sashimi.state import State
+from sashimi.gui.stage_gui import StageMotorWidget
 
 
 class DockedWidget(QDockWidget):
@@ -45,6 +46,7 @@ class MainWindow(QMainWindow):
         self.wid_camera = CameraSettingsWidget(st, self.wid_display, self.timer)
         self.wid_status_bar = StatusBarWidget(st, self.timer)
         self.toolbar = TopWidget(st, self.timer)
+        self.wid_stage = StageMotorWidget(st)
 
         self.addToolBar(Qt.TopToolBarArea, self.toolbar)
 
@@ -58,6 +60,11 @@ class MainWindow(QMainWindow):
         self.addDockWidget(
             Qt.RightDockWidgetArea,
             DockedWidget(widget=self.wid_scan, title="Scanning settings"),
+        )
+
+        self.addDockWidget(
+            Qt.RightDockWidgetArea,
+            DockedWidget(widget=self.wid_stage, title="Stage Motors"),
         )
 
         self.addDockWidget(
@@ -121,6 +128,7 @@ class MainWindow(QMainWindow):
         # TODO should be possible with lightparam, when it's implemented there remove here
         self.wid_laser.wid_settings.refresh_widgets()
         self.wid_scan.wid_planar.refresh_widgets()
+        self.wid_stage.wid_settings.refresh_widgets()
         self.wid_status.wid_volume.wid_volume.refresh_widgets()
         self.wid_status.wid_calibration.refresh_widgets()
         self.wid_status.wid_single_plane.wid_singleplane.refresh_widgets()

--- a/sashimi/gui/stage_gui.py
+++ b/sashimi/gui/stage_gui.py
@@ -1,0 +1,17 @@
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QCheckBox,
+)
+from lightparam.gui import ParameterGui
+
+
+
+class StageMotorWidget(QWidget):
+    def __init__(self, state):
+        super().__init__()
+        self.state = state
+        self.setLayout(QVBoxLayout())
+        self.wid_settings = ParameterGui(state.stage_setting)
+        self.layout().addWidget(self.wid_settings)
+

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -103,6 +103,15 @@ class CalibrationZSettings(ParametrizedQt):
         self.frontal = Param(0.0, (-2.0, 2.0), gui="slider")
 
 
+class StageMotorSettings(ParametrizedQt):
+    def __init__(self):
+        super().__init__()
+        self.name = "Stage Motors"
+        self.z_axis = Param(1.0, (0.0, 13.0), unit="mm", gui="slider")
+        self.x_axis = Param(1.0, (0.0, 13.0), unit="mm", gui="slider")
+        self.y_axis = Param(1.0, (0.0, 13.0), unit="mm", gui="slider")
+
+
 class SinglePlaneSettings(ParametrizedQt):
     def __init__(self):
         super().__init__()
@@ -389,6 +398,7 @@ class State:
         self.global_state = GlobalState.PAUSED
 
         self.planar_setting = PlanarScanningSettings()
+        self.stage_setting = StageMotorSettings()
         self.light_source_settings = LightSourceSettings()
         self.light_source_settings.params.intensity.unit = (
             self.light_source.intensity_units
@@ -402,6 +412,7 @@ class State:
 
         for setting in [
             self.planar_setting,
+            self.stage_setting,
             self.light_source_settings,
             self.single_plane_settings,
             self.volume_setting,


### PR DESCRIPTION
Simple widget to control the stage motors in the LFM setup. 
Ideally it should do the following things:

- open in the main window only if detects the motors
- control manually the motors
- home the motors
- create a sequence of steps

