### PR TITLE
Documentations deployment fix

### DIFF
--- a/.github/workflows/doc_deploy.yml
+++ b/.github/workflows/doc_deploy.yml
@@ -1,4 +1,4 @@
-name: 🚀 page_deploy
+name: 🚀 Deploy Documentation
 
 on:
   push:

--- a/.github/workflows/doc_deploy.yml
+++ b/.github/workflows/doc_deploy.yml
@@ -3,7 +3,7 @@ name: 🚀 Deploy Documentation
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     types:
       - assigned

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,25 @@
-name: tests
+name: 🤖 Lint - Tests - Deploy
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - assigned
+      - unassigned
+      - labeled
+      - unlabeled
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - locked
+      - unlocked
+      - review_requested
+      - review_request_
+  workflow_dispatch: 
 
 jobs:
   lint:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 docs:
 	rm -rf docs/_build/html
 	find docs/api ! -name 'index.rst' -type f -exec rm -f {} +
-	pip install -qr docs/requirements.txt
 	pip install -r requirements.txt
 	pip install -r requirements_dev.txt
 	pip install -e .

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,22 +1,19 @@
-- file: index
-
-- part: Overview
+format: jb-book
+root: index
+parts:
+- caption: Overview
   chapters:
-    - file: timeline
-
-- part: Configuration
+  - file: timeline
+- caption: Configuration
   chapters:
-    - file: configuration/installation
-    - file: configuration/configuration
-
-- part: Development
+  - file: configuration/installation
+  - file: configuration/configuration
+- caption: Development
   chapters:
-    - file: development/code_organization
-
-- part: Hardware
+  - file: development/code_organization
+- caption: Hardware
   chapters:
-    - file: hardware/hardware
-
-- part: Api
+  - file: hardware/hardware
+- caption: Api
   chapters:
-    - file: api/index
+  - file: api/index

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-jupyter-book
-jupytext
-sphinx_autodoc_typehints
-furo
-recommonmark

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,9 @@ pre-commit
 black==22.3.0
 flake8
 isort
+
+jupyter-book
+jupytext
+sphinx_autodoc_typehints
+furo
+recommonmark


### PR DESCRIPTION
The documentation deployment action wasn't working due to an update in the jupyter_books package

PR changes:
1. updated toc.yml file to work with the updated version of jupyter_books
2. changed name of the github actions
3. limited the run of lint/tests/package deployment to push on master and PRs
4. changed location of the docs requirements -> merged with requirements_dev.txt