### PR TITLE
Enforce Abstract

### DIFF
--- a/sashimi/hardware/cameras/interface.py
+++ b/sashimi/hardware/cameras/interface.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from abc import ABC, abstractmethod
 
+
 class CameraException(Exception):
     pass
 
@@ -18,7 +19,7 @@ class AbstractCamera(ABC):
     def __init__(self, camera_id, max_sensor_resolution=None):
         self.camera_id = camera_id
         self.max_sensor_resolution = max_sensor_resolution
-    
+
     @abstractmethod
     def get_frames(self):
         """
@@ -52,12 +53,12 @@ class AbstractCamera(ABC):
     @abstractmethod
     def exposure_time(self):
         return None
-    
+
     @exposure_time.setter
     @abstractmethod
     def exposure_time(self, exp_val):
         pass
-    
+
     @property
     @abstractmethod
     def binning(self):
@@ -67,7 +68,7 @@ class AbstractCamera(ABC):
     @abstractmethod
     def binning(self, exp_val):
         pass
-    
+
     @property
     @abstractmethod
     def roi(self):
@@ -77,7 +78,7 @@ class AbstractCamera(ABC):
     @abstractmethod
     def roi(self, exp_val: tuple):
         pass
-    
+
     @property
     @abstractmethod
     def trigger_mode(self):

--- a/sashimi/hardware/cameras/interface.py
+++ b/sashimi/hardware/cameras/interface.py
@@ -1,5 +1,5 @@
 from enum import Enum
-
+from abc import ABC, abstractmethod
 
 class CameraException(Exception):
     pass
@@ -14,11 +14,12 @@ class TriggerMode(Enum):
     EXTERNAL_TRIGGER = 2
 
 
-class AbstractCamera:
+class AbstractCamera(ABC):
     def __init__(self, camera_id, max_sensor_resolution=None):
         self.camera_id = camera_id
         self.max_sensor_resolution = max_sensor_resolution
-
+    
+    @abstractmethod
     def get_frames(self):
         """
         Returns a list of arrays, each of which corresponds to an available frame. If no frames where found returns an
@@ -26,18 +27,21 @@ class AbstractCamera:
         """
         pass
 
+    @abstractmethod
     def start_acquisition(self):
         """
         Allocate as many frames as will fit in 2GB of memory and start data acquisition.
         """
         pass
 
+    @abstractmethod
     def stop_acquisition(self):
         """
         Stop data acquisition and release the memory allocated for frames.
         """
         pass
 
+    @abstractmethod
     def shutdown(self):
         """
         Close down the connection to the camera.
@@ -45,38 +49,47 @@ class AbstractCamera:
         self.stop_acquisition()
 
     @property
+    @abstractmethod
     def exposure_time(self):
         return None
-
+    
     @exposure_time.setter
+    @abstractmethod
     def exposure_time(self, exp_val):
         pass
-
+    
     @property
+    @abstractmethod
     def binning(self):
         return None
 
     @binning.setter
+    @abstractmethod
     def binning(self, exp_val):
         pass
-
+    
     @property
+    @abstractmethod
     def roi(self):
         return None
 
     @roi.setter
+    @abstractmethod
     def roi(self, exp_val: tuple):
         pass
-
+    
     @property
+    @abstractmethod
     def trigger_mode(self):
         return None
 
     @trigger_mode.setter
+    @abstractmethod
     def trigger_mode(self, exp_val):
         pass
 
     @property
+    @abstractmethod
     def frame_rate(self):
         return None
 

--- a/sashimi/hardware/cameras/interface.py
+++ b/sashimi/hardware/cameras/interface.py
@@ -42,7 +42,6 @@ class AbstractCamera(ABC):
         """
         pass
 
-    @abstractmethod
     def shutdown(self):
         """
         Close down the connection to the camera.

--- a/sashimi/hardware/cameras/mock.py
+++ b/sashimi/hardware/cameras/mock.py
@@ -96,9 +96,3 @@ class MockCamera(AbstractCamera):
         Stop data acquisition and release the memory allocated for frames.
         """
         pass
-
-    def shutdown(self):
-        """
-        Close down the connection to the camera.
-        """
-        self.stop_acquisition()

--- a/sashimi/hardware/cameras/mock.py
+++ b/sashimi/hardware/cameras/mock.py
@@ -52,7 +52,7 @@ class MockCamera(AbstractCamera):
     def roi(self, exp_val: tuple):
         self._roi = exp_val
         self.prepare_mock_image()
-        
+
     @property
     def trigger_mode(self):
         return None

--- a/sashimi/hardware/cameras/mock.py
+++ b/sashimi/hardware/cameras/mock.py
@@ -52,6 +52,14 @@ class MockCamera(AbstractCamera):
     def roi(self, exp_val: tuple):
         self._roi = exp_val
         self.prepare_mock_image()
+        
+    @property
+    def trigger_mode(self):
+        return None
+
+    @trigger_mode.setter
+    def trigger_mode(self, exp_val):
+        pass
 
     def prepare_mock_image(self):
         self.current_mock_image = block_reduce(
@@ -76,3 +84,21 @@ class MockCamera(AbstractCamera):
         else:
             self.previous_frame_time = self.current_time
         return frames
+
+    def start_acquisition(self):
+        """
+        Allocate as many frames as will fit in 2GB of memory and start data acquisition.
+        """
+        pass
+
+    def stop_acquisition(self):
+        """
+        Stop data acquisition and release the memory allocated for frames.
+        """
+        pass
+
+    def shutdown(self):
+        """
+        Close down the connection to the camera.
+        """
+        self.stop_acquisition()

--- a/sashimi/hardware/external_trigger/interface.py
+++ b/sashimi/hardware/external_trigger/interface.py
@@ -1,9 +1,11 @@
 from typing import Optional
+from abc import ABC, abstractmethod
 
 
-class AbstractComm:
+class AbstractComm(ABC):
     def __init__(self, address):
         self.address = address
 
+    @abstractmethod
     def trigger_and_receive_duration(self, config) -> Optional[float]:
         return None

--- a/sashimi/hardware/light_source/cobolt.py
+++ b/sashimi/hardware/light_source/cobolt.py
@@ -54,7 +54,7 @@ class CoboltLaser(AbstractLightSource):
 
     def close(self):
         self.socket.close()
-    
+
     def set_power(self, current):
         """Sets power of laser based on self.intensity and self.intensity_units"""
         pass

--- a/sashimi/hardware/light_source/cobolt.py
+++ b/sashimi/hardware/light_source/cobolt.py
@@ -54,6 +54,10 @@ class CoboltLaser(AbstractLightSource):
 
     def close(self):
         self.socket.close()
+    
+    def set_power(self, current):
+        """Sets power of laser based on self.intensity and self.intensity_units"""
+        pass
 
     @property
     def intensity(self):

--- a/sashimi/hardware/light_source/interface.py
+++ b/sashimi/hardware/light_source/interface.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from abc import ABC, abstractmethod
 
 
 class LaserState(Enum):
@@ -14,34 +15,40 @@ class LaserWarning(Warning):
     pass
 
 
-class AbstractLightSource:
+class AbstractLightSource(ABC):
     def __init__(self, port):
         self.port = port
         self._status = LaserState.OFF
         self.intensity_units = None
 
-    def start(self):
+    def start(self):  #TODO: remove?
         pass
-
+    
+    @abstractmethod
     def set_power(self, current):
         """Sets power of laser based on self.intensity and self.intensity_units"""
         pass
 
+    @abstractmethod
     def close(self):
         pass
 
     @property
+    @abstractmethod
     def intensity(self):
         return None
 
     @intensity.setter
+    @abstractmethod
     def intensity(self, exp_val):
         pass
 
     @property
+    @abstractmethod
     def status(self):
         return self._status
 
     @status.setter
+    @abstractmethod
     def status(self, exp_val):
         pass

--- a/sashimi/hardware/light_source/interface.py
+++ b/sashimi/hardware/light_source/interface.py
@@ -21,9 +21,9 @@ class AbstractLightSource(ABC):
         self._status = LaserState.OFF
         self.intensity_units = None
 
-    def start(self):  #TODO: remove?
+    def start(self):
         pass
-    
+
     @abstractmethod
     def set_power(self, current):
         """Sets power of laser based on self.intensity and self.intensity_units"""

--- a/sashimi/hardware/light_source/mock.py
+++ b/sashimi/hardware/light_source/mock.py
@@ -7,6 +7,13 @@ class MockLaser(AbstractLightSource):
         self._current = 0
         self.intensity_units = "mocks"
 
+    def set_power(self, current):
+        """Sets power of laser based on self.intensity and self.intensity_units"""
+        pass
+    
+    def close(self):
+        pass
+    
     @property
     def intensity(self):
         return self._current
@@ -22,3 +29,5 @@ class MockLaser(AbstractLightSource):
     @status.setter
     def status(self, exp_val):
         self._status = exp_val
+        
+    

--- a/sashimi/hardware/light_source/mock.py
+++ b/sashimi/hardware/light_source/mock.py
@@ -10,10 +10,10 @@ class MockLaser(AbstractLightSource):
     def set_power(self, current):
         """Sets power of laser based on self.intensity and self.intensity_units"""
         pass
-    
+
     def close(self):
         pass
-    
+
     @property
     def intensity(self):
         return self._current
@@ -29,5 +29,3 @@ class MockLaser(AbstractLightSource):
     @status.setter
     def status(self, exp_val):
         self._status = exp_val
-        
-    

--- a/sashimi/hardware/scanning/__init__.py
+++ b/sashimi/hardware/scanning/__init__.py
@@ -12,62 +12,79 @@ class AbstractScanInterface(ABC):
         self.n_samples = n_samples
         self.conf = conf
 
+    @abstractmethod
     def start(self):
+        pass
+    
+    @abstractmethod
+    def write(self):
+        pass
+
+    @abstractmethod
+    def read(self):
         pass
 
     @property
+    @abstractmethod
     def z_piezo(self):
         return None
 
     @z_piezo.setter
+    @abstractmethod
     def z_piezo(self, waveform):
         pass
 
     @property
+    @abstractmethod
     def z_frontal(self):
         return None
 
     @z_frontal.setter
+    @abstractmethod
     def z_frontal(self, waveform):
         pass
 
     @property
+    @abstractmethod
     def z_lateral(self):
         return None
 
     @z_lateral.setter
+    @abstractmethod
     def z_lateral(self, waveform):
         pass
 
     @property
+    @abstractmethod
     def camera_trigger(self):
         return None
 
     @camera_trigger.setter
+    @abstractmethod
     def camera_trigger(self, waveform):
         pass
 
     @property
+    @abstractmethod
     def xy_frontal(self):
         return None
 
     @xy_frontal.setter
+    @abstractmethod
     def xy_frontal(self, waveform):
         pass
 
     @property
+    @abstractmethod
     def xy_lateral(self):
         return None
 
     @xy_lateral.setter
+    @abstractmethod
     def xy_lateral(self, waveform):
         pass
 
-    def write(self):
-        pass
-
-    def read(self):
-        pass
+    
 
 
 @contextmanager

--- a/sashimi/hardware/scanning/__init__.py
+++ b/sashimi/hardware/scanning/__init__.py
@@ -1,11 +1,13 @@
+import abc
 from contextlib import contextmanager
+from abc import ABC, abstractmethod
 
 
 class ScanningError(Exception):
     pass
 
 
-class AbstractScanInterface:
+class AbstractScanInterface(ABC):
     def __init__(self, sample_rate, n_samples, conf, *args, **kwargs):
         self.sample_rate = sample_rate
         self.n_samples = n_samples

--- a/sashimi/hardware/scanning/__init__.py
+++ b/sashimi/hardware/scanning/__init__.py
@@ -15,7 +15,7 @@ class AbstractScanInterface(ABC):
     @abstractmethod
     def start(self):
         pass
-    
+
     @abstractmethod
     def write(self):
         pass
@@ -83,8 +83,6 @@ class AbstractScanInterface(ABC):
     @abstractmethod
     def xy_lateral(self, waveform):
         pass
-
-    
 
 
 @contextmanager

--- a/sashimi/hardware/scanning/__init__.py
+++ b/sashimi/hardware/scanning/__init__.py
@@ -1,4 +1,3 @@
-import abc
 from contextlib import contextmanager
 from abc import ABC, abstractmethod
 

--- a/sashimi/hardware/scanning/mock.py
+++ b/sashimi/hardware/scanning/mock.py
@@ -9,6 +9,16 @@ class MockBoard(AbstractScanInterface):
         super().__init__(sample_rate, n_samples, conf)
         self.piezo_array = np.zeros(n_samples)
 
+    def start(self):
+        pass
+
+    def read(self):
+        sleep(0.05)
+
+    def write(self):
+        sleep(0.05)
+        
+        
     @property
     def z_piezo(self):
         len_sampling = len(self.piezo_array)
@@ -18,11 +28,45 @@ class MockBoard(AbstractScanInterface):
     def z_piezo(self, waveform):
         self.piezo_array[:] = waveform
 
-    def read(self):
-        sleep(0.05)
+    @property
+    def z_frontal(self):
+        return None
 
-    def write(self):
-        sleep(0.05)
+    @z_frontal.setter
+    def z_frontal(self, waveform):
+        pass
+
+    @property
+    def z_lateral(self):
+        return None
+
+    @z_lateral.setter
+    def z_lateral(self, waveform):
+        pass
+
+    @property
+    def camera_trigger(self):
+        return None
+
+    @camera_trigger.setter
+    def camera_trigger(self, waveform):
+        pass
+
+    @property
+    def xy_frontal(self):
+        return None
+
+    @xy_frontal.setter
+    def xy_frontal(self, waveform):
+        pass
+
+    @property
+    def xy_lateral(self):
+        return None
+
+    @xy_lateral.setter
+    def xy_lateral(self, waveform):
+        pass
 
 
 @contextmanager

--- a/sashimi/hardware/scanning/mock.py
+++ b/sashimi/hardware/scanning/mock.py
@@ -17,8 +17,7 @@ class MockBoard(AbstractScanInterface):
 
     def write(self):
         sleep(0.05)
-        
-        
+
     @property
     def z_piezo(self):
         len_sampling = len(self.piezo_array)


### PR DESCRIPTION
making abstract classes and interfaces inherit from abc:
- would prevent to initialize an instance of an abstract class 
- would prevent to initialize a class without having overwritten all the abstract methods