### PR TITLE
Fix issue #138

### DIFF
--- a/sashimi/hardware/cameras/mock.py
+++ b/sashimi/hardware/cameras/mock.py
@@ -79,7 +79,7 @@ class MockCamera(AbstractCamera):
             self.elapsed = (self.current_time - self.previous_frame_time) * 1e-9
             if self.elapsed >= self._exposure_time * 1e-3:
                 multiplier = np.random.randint(1, 5, 1)
-                frames.append(self.current_mock_image * multiplier)
+                frames.append(np.uint16(self.current_mock_image * multiplier))
                 self.previous_frame_time = self.current_time
         else:
             self.previous_frame_time = self.current_time

--- a/sashimi/processes/dispatcher.py
+++ b/sashimi/processes/dispatcher.py
@@ -64,7 +64,8 @@ class VolumeDispatcher(LoggingProcess):
 
     def process_frame(self, current_frame):
         if self.calibration_ref is not None and self.noise_subtraction_active.is_set():
-            current_frame = neg_dif(current_frame, self.calibration_ref)
+            if np.shape(current_frame) == np.shape(self.calibration_ref):
+                current_frame = neg_dif(current_frame, self.calibration_ref)
 
         if self.first_volume or self.volume_buffer.shape[1:3] != current_frame.shape:
             self.volume_buffer = np.empty(

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -597,11 +597,12 @@ class State:
                 calibration_set[n_image, :, :] = current_image
                 n_image += 1
 
-        self.noise_subtraction_active.set()
         self.calibration_ref = np.mean(calibration_set, axis=0).astype(
             dtype=current_volume.dtype
         )
         self.light_source.intensity = light_intensity
+
+        self.noise_subtraction_active.set()
 
         self.dispatcher.calibration_ref_queue.put(self.calibration_ref)
 


### PR DESCRIPTION
After fidgeting around with the issue #138  here's what I've found:

reminder: the crash happens because the two images (current frame and calibration ref) don't have the same size

The problem lies in the fact that we used to set `self.noise_subtraction_active.set()` before overwriting `self.calibration_ref`

Now, one thing that doesn't convince me is that if I move `self.noise_subtraction_active.set()` directly below `self.calibration_ref` it will still crash

Another useful information is that if I implement a check before calling `neg_dif` then I get two skips (two current frames that can't be processed) and then the `self.calibration_ref` seems to be updated normally

So my hypothesis is that it could be a timing problem between the update of `self.calibration_ref` and the setting `self.noise_subtraction_active.set()` 

If that sounds convincing then I'd propose to implement a sanity check before applying the neg_diff? 
the check I'm suggesting would look like this:
```python
if np.shape(current_frame) == np.shape(self.calibration_ref):
    current_frame = neg_dif(current_frame, self.calibration_ref)
else:
    #flag the user in some way -> warning?

```

## Conclusion
The fix implemented here seems to work and prevent successfully the crash 

however it's very possible that it's only a matter of timing and thing could go wrong on a different setup -> as such it may be a good idea to implement a check on the size of the images before performing the noise subtraction 

Another option is to further investigate the root cause of the "late" update of `self.calibration_ref` in which case I may need some guidance on where to look
