### PR TITLE
Disable gui while experiment is running

### DIFF
--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -12,7 +12,7 @@ from sashimi.gui.camera_gui import ViewingWidget, CameraSettingsWidget
 from sashimi.gui.save_gui import SaveWidget
 from sashimi.gui.status_bar import StatusBarWidget
 from sashimi.gui.top_bar import TopWidget
-from sashimi.state import GlobalState, State
+from sashimi.state import State
 
 
 class DockedWidget(QDockWidget):
@@ -45,7 +45,6 @@ class MainWindow(QMainWindow):
         self.wid_camera = CameraSettingsWidget(st, self.wid_display, self.timer)
         self.wid_status_bar = StatusBarWidget(st, self.timer)
         self.toolbar = TopWidget(st, self.timer)
-        self.prev_exp_state = GlobalState.PAUSED
 
         self.addToolBar(Qt.TopToolBarArea, self.toolbar)
 
@@ -145,18 +144,10 @@ class MainWindow(QMainWindow):
             self.toolbar.experiment_toggle_btn.flip_icon(False)
 
         # check if experiment started or ended and update gui enabling
-        if (
-            self.st.is_exp_running == GlobalState.EXPERIMENT_RUNNING
-            and self.prev_exp_state == GlobalState.PAUSED
-        ):
+        if self.st.is_exp_started():
             self.disable_gui()
-            self.prev_exp_state = GlobalState.EXPERIMENT_RUNNING
-        elif (
-            self.st.is_exp_running == GlobalState.PAUSED
-            and self.prev_exp_state == GlobalState.EXPERIMENT_RUNNING
-        ):
+        elif self.st.is_exp_ended():
             self.enable_gui()
-            self.prev_exp_state = GlobalState.PAUSED
 
     def disable_gui(self):
         """Disable all the gui elements during the experiment"""
@@ -166,7 +157,7 @@ class MainWindow(QMainWindow):
         self.wid_scan.setEnabled(False)
         self.wid_camera.setEnabled(False)
         self.wid_save_options.setEnabled(False)
-        self.wid_display.setEnabled(False)
+        self.wid_display.auto_contrast_chk.setEnabled(False)
 
     def enable_gui(self):
         """Enables all the gui elements after the end of the experiment"""
@@ -176,7 +167,7 @@ class MainWindow(QMainWindow):
         self.wid_scan.setEnabled(True)
         self.wid_camera.setEnabled(True)
         self.wid_save_options.setEnabled(True)
-        self.wid_display.setEnabled(True)
+        self.wid_display.auto_contrast_chk.setEnabled(True)
 
 
 class StatusWidget(QTabWidget):

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -147,7 +147,7 @@ class MainWindow(QMainWindow):
         if self.st.is_exp_started():
             self.set_enabled_gui(enable=False)
         elif self.st.is_exp_ended():
-            self.set_enabled_gui(enable=False)
+            self.set_enabled_gui(enable=True)
 
     def set_enabled_gui(self, enable):
         """Disable all the gui elements during the experiment"""

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -143,19 +143,23 @@ class MainWindow(QMainWindow):
             self.toolbar.lbl_experiment_progress.hide()
             self.st.saver.saver_stopped_signal.clear()
             self.toolbar.experiment_toggle_btn.flip_icon(False)
-            
-        #check if experiment started or ended and update gui enabling
-        if self.st.is_exp_running == GlobalState.EXPERIMENT_RUNNING and self.prev_exp_state == GlobalState.PAUSED:
+
+        # check if experiment started or ended and update gui enabling
+        if (
+            self.st.is_exp_running == GlobalState.EXPERIMENT_RUNNING
+            and self.prev_exp_state == GlobalState.PAUSED
+        ):
             self.disable_gui()
             self.prev_exp_state = GlobalState.EXPERIMENT_RUNNING
-        elif self.st.is_exp_running == GlobalState.PAUSED and self.prev_exp_state == GlobalState.EXPERIMENT_RUNNING:
+        elif (
+            self.st.is_exp_running == GlobalState.PAUSED
+            and self.prev_exp_state == GlobalState.EXPERIMENT_RUNNING
+        ):
             self.enable_gui()
             self.prev_exp_state = GlobalState.PAUSED
-            
-            
+
     def disable_gui(self):
-        """Disable all the gui elements during the experiment
-        """
+        """Disable all the gui elements during the experiment"""
         self.menuBar().setEnabled(False)
         self.wid_laser.setEnabled(False)
         self.wid_status.setEnabled(False)
@@ -163,10 +167,9 @@ class MainWindow(QMainWindow):
         self.wid_camera.setEnabled(False)
         self.wid_save_options.setEnabled(False)
         self.wid_display.setEnabled(False)
-        
+
     def enable_gui(self):
-        """Enables all the gui elements after the end of the experiment
-        """
+        """Enables all the gui elements after the end of the experiment"""
         self.menuBar().setEnabled(True)
         self.wid_laser.setEnabled(True)
         self.wid_status.setEnabled(True)
@@ -174,6 +177,7 @@ class MainWindow(QMainWindow):
         self.wid_camera.setEnabled(True)
         self.wid_save_options.setEnabled(True)
         self.wid_display.setEnabled(True)
+
 
 class StatusWidget(QTabWidget):
     def __init__(self, st: State, timer):

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -145,29 +145,19 @@ class MainWindow(QMainWindow):
 
         # check if experiment started or ended and update gui enabling
         if self.st.is_exp_started():
-            self.disable_gui()
+            self.set_enabled_gui(enable=False)
         elif self.st.is_exp_ended():
-            self.enable_gui()
+            self.set_enabled_gui(enable=False)
 
-    def disable_gui(self):
+    def set_enabled_gui(self, enable):
         """Disable all the gui elements during the experiment"""
-        self.menuBar().setEnabled(False)
-        self.wid_laser.setEnabled(False)
-        self.wid_status.setEnabled(False)
-        self.wid_scan.setEnabled(False)
-        self.wid_camera.setEnabled(False)
-        self.wid_save_options.setEnabled(False)
-        self.wid_display.auto_contrast_chk.setEnabled(False)
-
-    def enable_gui(self):
-        """Enables all the gui elements after the end of the experiment"""
-        self.menuBar().setEnabled(True)
-        self.wid_laser.setEnabled(True)
-        self.wid_status.setEnabled(True)
-        self.wid_scan.setEnabled(True)
-        self.wid_camera.setEnabled(True)
-        self.wid_save_options.setEnabled(True)
-        self.wid_display.auto_contrast_chk.setEnabled(True)
+        self.menuBar().setEnabled(enable)
+        self.wid_laser.setEnabled(enable)
+        self.wid_status.setEnabled(enable)
+        self.wid_scan.setEnabled(enable)
+        self.wid_camera.setEnabled(enable)
+        self.wid_save_options.setEnabled(enable)
+        self.wid_display.auto_contrast_chk.setEnabled(enable)
 
 
 class StatusWidget(QTabWidget):

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -12,7 +12,7 @@ from sashimi.gui.camera_gui import ViewingWidget, CameraSettingsWidget
 from sashimi.gui.save_gui import SaveWidget
 from sashimi.gui.status_bar import StatusBarWidget
 from sashimi.gui.top_bar import TopWidget
-from sashimi.state import State
+from sashimi.state import GlobalState, State
 
 
 class DockedWidget(QDockWidget):
@@ -45,6 +45,7 @@ class MainWindow(QMainWindow):
         self.wid_camera = CameraSettingsWidget(st, self.wid_display, self.timer)
         self.wid_status_bar = StatusBarWidget(st, self.timer)
         self.toolbar = TopWidget(st, self.timer)
+        self.prev_exp_state = GlobalState.PAUSED
 
         self.addToolBar(Qt.TopToolBarArea, self.toolbar)
 
@@ -142,7 +143,37 @@ class MainWindow(QMainWindow):
             self.toolbar.lbl_experiment_progress.hide()
             self.st.saver.saver_stopped_signal.clear()
             self.toolbar.experiment_toggle_btn.flip_icon(False)
-
+            
+        #check if experiment started or ended and update gui enabling
+        if self.st.is_exp_running == GlobalState.EXPERIMENT_RUNNING and self.prev_exp_state == GlobalState.PAUSED:
+            self.disable_gui()
+            self.prev_exp_state = GlobalState.EXPERIMENT_RUNNING
+        elif self.st.is_exp_running == GlobalState.PAUSED and self.prev_exp_state == GlobalState.EXPERIMENT_RUNNING:
+            self.enable_gui()
+            self.prev_exp_state = GlobalState.PAUSED
+            
+            
+    def disable_gui(self):
+        """Disable all the gui elements during the experiment
+        """
+        self.menuBar().setEnabled(False)
+        self.wid_laser.setEnabled(False)
+        self.wid_status.setEnabled(False)
+        self.wid_scan.setEnabled(False)
+        self.wid_camera.setEnabled(False)
+        self.wid_save_options.setEnabled(False)
+        self.wid_display.setEnabled(False)
+        
+    def enable_gui(self):
+        """Enables all the gui elements after the end of the experiment
+        """
+        self.menuBar().setEnabled(True)
+        self.wid_laser.setEnabled(True)
+        self.wid_status.setEnabled(True)
+        self.wid_scan.setEnabled(True)
+        self.wid_camera.setEnabled(True)
+        self.wid_save_options.setEnabled(True)
+        self.wid_display.setEnabled(True)
 
 class StatusWidget(QTabWidget):
     def __init__(self, st: State, timer):

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -387,7 +387,8 @@ class State:
         self.settings_tree = ParameterTree()
 
         self.global_state = GlobalState.PAUSED
-        self.is_exp_running = GlobalState.PAUSED
+        self.current_exp_state = GlobalState.PAUSED
+        self.prev_exp_state = self.current_exp_state
 
         self.planar_setting = PlanarScanningSettings()
         self.light_source_settings = LightSourceSettings()
@@ -555,7 +556,7 @@ class State:
 
     def start_experiment(self):
         # TODO disable the GUI except the abort button
-        self.is_exp_running = GlobalState.EXPERIMENT_RUNNING
+        self.current_exp_state = GlobalState.EXPERIMENT_RUNNING
         self.logger.log_message("started experiment")
         self.scanner.wait_signal.set()
         self.send_scansave_settings()
@@ -571,7 +572,41 @@ class State:
         self.experiment_start_event.clear()
         self.saver.save_queue.clear()
         self.send_scansave_settings()
-        self.is_exp_running = GlobalState.PAUSED
+        self.current_exp_state = GlobalState.PAUSED
+
+    def is_exp_started(self) -> bool:
+        """
+        check if the experiment has started:
+        looks for tha change in the value hold by current_exp_running
+
+        Returns:
+            bool
+        """
+        if (
+            self.current_exp_state == GlobalState.EXPERIMENT_RUNNING
+            and self.prev_exp_state == GlobalState.PAUSED
+        ):
+            self.prev_exp_state = GlobalState.EXPERIMENT_RUNNING
+            return True
+        else:
+            return False
+
+    def is_exp_ended(self) -> bool:
+        """
+        check if the experiment has ended:
+        looks for tha change in the value hold by current_exp_running
+
+        Returns:
+            bool
+        """
+        if (
+            self.prev_exp_state == GlobalState.EXPERIMENT_RUNNING
+            and self.current_exp_state == GlobalState.PAUSED
+        ):
+            self.prev_exp_state = GlobalState.PAUSED
+            return True
+        else:
+            return False
 
     def obtain_noise_average(self, n_images=50):
         """Obtains average noise of n_images to subtract to acquired,

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -387,6 +387,7 @@ class State:
         self.settings_tree = ParameterTree()
 
         self.global_state = GlobalState.PAUSED
+        self.is_exp_running = GlobalState.PAUSED
 
         self.planar_setting = PlanarScanningSettings()
         self.light_source_settings = LightSourceSettings()
@@ -554,6 +555,7 @@ class State:
 
     def start_experiment(self):
         # TODO disable the GUI except the abort button
+        self.is_exp_running = GlobalState.EXPERIMENT_RUNNING
         self.logger.log_message("started experiment")
         self.scanner.wait_signal.set()
         self.send_scansave_settings()
@@ -569,6 +571,7 @@ class State:
         self.experiment_start_event.clear()
         self.saver.save_queue.clear()
         self.send_scansave_settings()
+        self.is_exp_running = GlobalState.PAUSED
 
     def obtain_noise_average(self, n_images=50):
         """Obtains average noise of n_images to subtract to acquired,


### PR DESCRIPTION
In this PR there's two major changes:

- there's a new variable `is_exp_running` which holds the `GlobalState.EXPERIMENT_RUNNING` 
- this variable is used in the main gui to enable and disable the gui during the experiment

## Advice/Suggestions needed:
1. first the name of the variable is misleading because it seems to hold a boolean -> new name needed or see point 2
2. i'm using the global state class because I reckon it was a pity to have and not use for this, however it may make more sense to use the variable `is_exp_running` as a boolean and get rid of the `GlobalState.EXPERIMENT_RUNNING`  since is not used anywhere -> any suggestions regarding this?

