### PR TITLE
Drift Visualization

### DIFF
--- a/sashimi/gui/camera_gui.py
+++ b/sashimi/gui/camera_gui.py
@@ -84,7 +84,6 @@ class ViewingWidget(QWidget):
         self.auto_contrast = True
         self.is_exp_started = False
         self.is_exp_ended = False
-        
         self.is_drift_active = False
 
         s = self.get_fullframe_size()
@@ -107,6 +106,7 @@ class ViewingWidget(QWidget):
             visible=True,
         )
 
+        # create drift layer and set it as not visible
         self.drift_layer = self.viewer.add_image(
             np.zeros(
                 [
@@ -244,14 +244,14 @@ class ViewingWidget(QWidget):
         self.frame_layer.data = current_image
         # self.frame_layer.scale = [self.voxel_size[0] / self.voxel_size[1], 1.0, 1.0]
 
+        # If experiment is started/ended call the display drift function
         if self.is_exp_started:
-            self.display_drift(frame = current_image, is_exp_running=True)
+            self.display_drift(frame=current_image, is_exp_running=True)
             self.is_exp_started = False
         elif self.is_exp_ended:
             self.display_drift(is_exp_running=False)
             self.is_exp_ended = False
-        
-        
+
         # Check if anything changed in the image shape, which would mean that changes of the contrast
         # are required (in case a parameter update was missed).
         if self.is_first_frame or self.image_shape != current_image.shape:
@@ -298,27 +298,43 @@ class ViewingWidget(QWidget):
     def set_manual_contrast(self):
         self.frame_layer.contrast_limits = self.contrast_range.contrast_range
 
-    def activate_drift_reference(self):
-        # self.state.is_drift_active = not self.state.is_drift_active
+    def activate_drift_reference(self) -> None:
+        """
+        If active the first volume during the experiment
+        will be saved and overlayed to the viewer
+        """
         self.is_drift_active = not self.is_drift_active
 
-    def display_drift_reference(self):
-        if self.drift_layer.data is not None:
+    def display_drift_reference(self) -> None:
+        """
+        Toggles the visualization of the drift layer on/off
+        """
+        # if not None or empty
+        if self.drift_layer.data is not None or np.any(self.drift_layer.data):
             self.drift_layer.visible = not self.drift_layer.visible
-        else:
-            print("Error: drift was inactive before start of acquisition")
-            
-    def display_frame_reference(self):
+
+    def display_frame_reference(self) -> None:
+        """
+        Toggles the visualization of the main layer on/off
+        """
         self.frame_layer.visible = not self.frame_layer.visible
-        
-    def display_drift(self, frame = None, is_exp_running = False):
-        if (is_exp_running
-            and self.is_drift_active
-            and frame is not None
-        ):
+
+    def display_drift(self, frame=None, is_exp_running=False) -> None:
+        """
+        If the conditions are right displays the drift layer,
+        else it will disable the buttons and reset the drift layer
+
+        Args:
+            frame (np.ndarray): current image used to refresh the viewer after the experiment started.
+                                Defaults to None.
+            is_exp_running (bool): check to discriminate between start and end of the experiment.
+                                            Defaults to False.
+        """
+        # if experiment started, button is selected and frame has been generated
+        if is_exp_running and self.is_drift_active and frame is not None:
             # set layer data
             self.drift_layer.data = frame
-            self.drift_layer.contrast_limits= self.frame_layer.contrast_limits
+            self.drift_layer.contrast_limits = self.frame_layer.contrast_limits
             # set buttons
             self.display_drift_chk.setEnabled(True)
             self.display_drift_chk.setChecked(True)
@@ -331,8 +347,7 @@ class ViewingWidget(QWidget):
             # set layer visibility
             self.drift_layer.visible = False
             # reset drift image
-            self.drift_layer.data = np.zeros([2,2])
-
+            self.drift_layer.data = np.zeros([2, 2])
 
 
 class CameraSettingsWidget(QWidget):

--- a/sashimi/gui/camera_gui.py
+++ b/sashimi/gui/camera_gui.py
@@ -110,9 +110,8 @@ class ViewingWidget(QWidget):
         self.drift_layer = self.viewer.add_image(
             np.zeros(
                 [
-                    1,
+                    1, 5, 5,
                 ]
-                + self.max_sensor_resolution
             ),
             blending="additive",
             name="drift_layer",
@@ -155,7 +154,7 @@ class ViewingWidget(QWidget):
 
         self.active_drift_chk = QCheckBox("Activate Drift Reference")
         self.display_drift_chk = QCheckBox("Visualize/Hide Drift Reference")
-        self.display_frame_chk = QCheckBox("Visualize/Hide Frame Reference")
+        self.display_frame_chk = QCheckBox("Visualize/Hide Live View")
 
         self.bottom_layout.addWidget(self.auto_contrast_chk)
         self.bottom_layout.addWidget(self.wid_contrast_range)
@@ -177,12 +176,15 @@ class ViewingWidget(QWidget):
         self.active_drift_chk.clicked.connect(self.activate_drift_reference)
         self.display_drift_chk.clicked.connect(self.display_drift_reference)
         self.display_frame_chk.clicked.connect(self.display_frame_reference)
+        
+        self.display_frame_chk.setChecked(True)
+        self.display_frame_chk.setEnabled(False)
         self.display_drift_chk.setEnabled(
             False
         )  # only enabled if drift reference is activated
 
         self.auto_contrast_chk.setChecked(True)
-        self.display_frame_chk.setChecked(True)
+        
 
         self.state.camera_settings.sig_param_changed.connect(
             self.launch_delayed_contrast_reset
@@ -336,18 +338,25 @@ class ViewingWidget(QWidget):
             self.drift_layer.data = frame
             self.drift_layer.contrast_limits = self.frame_layer.contrast_limits
             # set buttons
+            #-> drift is active -> all buttons on
             self.display_drift_chk.setEnabled(True)
             self.display_drift_chk.setChecked(True)
+            self.display_frame_chk.setChecked(True)
+            self.display_frame_chk.setEnabled(True)
             # set layer visibility
             self.drift_layer.visible = True
         else:
             # set buttons
+            # -> drift inactive all buttons off
             self.display_drift_chk.setEnabled(False)
             self.display_drift_chk.setChecked(False)
+            self.display_frame_chk.setChecked(True)  #live view on
+            self.display_frame_chk.setEnabled(False)
             # set layer visibility
             self.drift_layer.visible = False
+            self.frame_layer.visible = True #live view on
             # reset drift image
-            self.drift_layer.data = np.zeros([2, 2])
+            self.drift_layer.data = self.frame_layer.data * 0
 
 
 class CameraSettingsWidget(QWidget):

--- a/sashimi/gui/camera_gui.py
+++ b/sashimi/gui/camera_gui.py
@@ -110,7 +110,9 @@ class ViewingWidget(QWidget):
         self.drift_layer = self.viewer.add_image(
             np.zeros(
                 [
-                    1, 5, 5,
+                    1,
+                    5,
+                    5,
                 ]
             ),
             blending="additive",
@@ -176,7 +178,7 @@ class ViewingWidget(QWidget):
         self.active_drift_chk.clicked.connect(self.activate_drift_reference)
         self.display_drift_chk.clicked.connect(self.display_drift_reference)
         self.display_frame_chk.clicked.connect(self.display_frame_reference)
-        
+
         self.display_frame_chk.setChecked(True)
         self.display_frame_chk.setEnabled(False)
         self.display_drift_chk.setEnabled(
@@ -184,7 +186,6 @@ class ViewingWidget(QWidget):
         )  # only enabled if drift reference is activated
 
         self.auto_contrast_chk.setChecked(True)
-        
 
         self.state.camera_settings.sig_param_changed.connect(
             self.launch_delayed_contrast_reset
@@ -338,7 +339,7 @@ class ViewingWidget(QWidget):
             self.drift_layer.data = frame
             self.drift_layer.contrast_limits = self.frame_layer.contrast_limits
             # set buttons
-            #-> drift is active -> all buttons on
+            # -> drift is active -> all buttons on
             self.display_drift_chk.setEnabled(True)
             self.display_drift_chk.setChecked(True)
             self.display_frame_chk.setChecked(True)
@@ -350,11 +351,11 @@ class ViewingWidget(QWidget):
             # -> drift inactive all buttons off
             self.display_drift_chk.setEnabled(False)
             self.display_drift_chk.setChecked(False)
-            self.display_frame_chk.setChecked(True)  #live view on
+            self.display_frame_chk.setChecked(True)  # live view on
             self.display_frame_chk.setEnabled(False)
             # set layer visibility
             self.drift_layer.visible = False
-            self.frame_layer.visible = True #live view on
+            self.frame_layer.visible = True  # live view on
             # reset drift image
             self.drift_layer.data = self.frame_layer.data * 0
 

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -158,6 +158,10 @@ class MainWindow(QMainWindow):
         self.wid_camera.setEnabled(enable)
         self.wid_save_options.setEnabled(enable)
         self.wid_display.auto_contrast_chk.setEnabled(enable)
+        self.wid_display.active_drift_chk.setEnabled(enable)
+        self.wid_display.display_drift(
+            is_exp_started=not enable
+        )  # notifies the viewing widget to display drift layer
 
 
 class StatusWidget(QTabWidget):

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -146,8 +146,11 @@ class MainWindow(QMainWindow):
         # check if experiment started or ended and update gui enabling
         if self.st.is_exp_started():
             self.set_enabled_gui(enable=False)
+            self.wid_display.is_exp_started = True
+            
         elif self.st.is_exp_ended():
             self.set_enabled_gui(enable=True)
+            self.wid_display.is_exp_ended = True
 
     def set_enabled_gui(self, enable):
         """Disable all the gui elements during the experiment"""
@@ -159,9 +162,7 @@ class MainWindow(QMainWindow):
         self.wid_save_options.setEnabled(enable)
         self.wid_display.auto_contrast_chk.setEnabled(enable)
         self.wid_display.active_drift_chk.setEnabled(enable)
-        self.wid_display.display_drift(
-            is_exp_started=not enable
-        )  # notifies the viewing widget to display drift layer
+
 
 
 class StatusWidget(QTabWidget):

--- a/sashimi/gui/main_gui.py
+++ b/sashimi/gui/main_gui.py
@@ -146,14 +146,19 @@ class MainWindow(QMainWindow):
         # check if experiment started or ended and update gui enabling
         if self.st.is_exp_started():
             self.set_enabled_gui(enable=False)
+            # pass down to the display window the information
             self.wid_display.is_exp_started = True
-            
+
         elif self.st.is_exp_ended():
             self.set_enabled_gui(enable=True)
+            # pass down to the display window the information
             self.wid_display.is_exp_ended = True
 
     def set_enabled_gui(self, enable):
-        """Disable all the gui elements during the experiment"""
+        """
+        Disable all the gui elements during the experiment
+        and re-enables them after
+        """
         self.menuBar().setEnabled(enable)
         self.wid_laser.setEnabled(enable)
         self.wid_status.setEnabled(enable)
@@ -162,7 +167,6 @@ class MainWindow(QMainWindow):
         self.wid_save_options.setEnabled(enable)
         self.wid_display.auto_contrast_chk.setEnabled(enable)
         self.wid_display.active_drift_chk.setEnabled(enable)
-
 
 
 class StatusWidget(QTabWidget):

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -554,8 +554,11 @@ class State:
         self.saver.saving_parameter_queue.put(self.save_params)
         self.dispatcher.n_planes_queue.put(self.n_planes)
 
-    def start_experiment(self):
-
+    def start_experiment(self) -> None:
+        """
+        Sets all the signals and cleans the queue
+        to trigger the start of the experiment
+        """
         self.current_exp_state = GlobalState.EXPERIMENT_RUNNING
         self.logger.log_message("started experiment")
         self.scanner.wait_signal.set()
@@ -566,7 +569,11 @@ class State:
         time.sleep(0.01)
         self.is_saving_event.set()
 
-    def end_experiment(self):
+    def end_experiment(self) -> None:
+        """
+        Sets all the signals and cleans the queue
+        to trigger the end of the experiment
+        """
         self.logger.log_message("experiment ended")
         self.is_saving_event.clear()
         self.experiment_start_event.clear()
@@ -577,7 +584,7 @@ class State:
     def is_exp_started(self) -> bool:
         """
         check if the experiment has started:
-        looks for tha change in the value hold by current_exp_running
+        looks for tha change in the value hold by current_exp_state
 
         Returns:
             bool
@@ -594,7 +601,7 @@ class State:
     def is_exp_ended(self) -> bool:
         """
         check if the experiment has ended:
-        looks for tha change in the value hold by current_exp_running
+        looks for tha change in the value hold by current_exp_state
 
         Returns:
             bool
@@ -645,6 +652,7 @@ class State:
         self.dispatcher.calibration_ref_queue.put(self.calibration_ref)
 
     def reset_noise_subtraction(self):
+
         self.calibration_ref = None
         self.noise_subtraction_active.clear()
 

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -310,8 +310,6 @@ class State:
         self.logger = ConcurrenceLogger("main")
 
         self.calibration_ref = None
-        self.drift_ref = None
-        self.is_drift_active = False
         self.waveform = None
         self.current_plane = 0
         self.stop_event = LoggedEvent(self.logger, SashimiEvents.CLOSE_ALL)
@@ -558,8 +556,6 @@ class State:
 
     def start_experiment(self):
 
-        if self.is_drift_active:
-            self.get_drift_reference()
         self.current_exp_state = GlobalState.EXPERIMENT_RUNNING
         self.logger.log_message("started experiment")
         self.scanner.wait_signal.set()
@@ -576,7 +572,6 @@ class State:
         self.experiment_start_event.clear()
         self.saver.save_queue.clear()
         self.send_scansave_settings()
-        self.reset_drift_reference()
         self.current_exp_state = GlobalState.PAUSED
 
     def is_exp_started(self) -> bool:
@@ -652,14 +647,6 @@ class State:
     def reset_noise_subtraction(self):
         self.calibration_ref = None
         self.noise_subtraction_active.clear()
-
-    def reset_drift_reference(self):
-        self.drift_ref = None
-
-    def get_drift_reference(self):
-        self.drift_ref = None
-        while self.drift_ref is None:
-            self.drift_ref = self.get_volume()
 
     def get_volume(self):
         # TODO consider get_last_parameters method

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -310,6 +310,8 @@ class State:
         self.logger = ConcurrenceLogger("main")
 
         self.calibration_ref = None
+        self.drift_ref = None
+        self.is_drift_active = False
         self.waveform = None
         self.current_plane = 0
         self.stop_event = LoggedEvent(self.logger, SashimiEvents.CLOSE_ALL)
@@ -555,7 +557,9 @@ class State:
         self.dispatcher.n_planes_queue.put(self.n_planes)
 
     def start_experiment(self):
-        # TODO disable the GUI except the abort button
+
+        if self.is_drift_active:
+            self.get_drift_reference()
         self.current_exp_state = GlobalState.EXPERIMENT_RUNNING
         self.logger.log_message("started experiment")
         self.scanner.wait_signal.set()
@@ -572,6 +576,7 @@ class State:
         self.experiment_start_event.clear()
         self.saver.save_queue.clear()
         self.send_scansave_settings()
+        self.reset_drift_reference()
         self.current_exp_state = GlobalState.PAUSED
 
     def is_exp_started(self) -> bool:
@@ -647,6 +652,14 @@ class State:
     def reset_noise_subtraction(self):
         self.calibration_ref = None
         self.noise_subtraction_active.clear()
+
+    def reset_drift_reference(self):
+        self.drift_ref = None
+
+    def get_drift_reference(self):
+        self.drift_ref = None
+        while self.drift_ref is None:
+            self.drift_ref = self.get_volume()
 
     def get_volume(self):
         # TODO consider get_last_parameters method


### PR DESCRIPTION
Simple Feature to visualize the first plane/volume of the acquisition overlay on the current volume.

1.  - [x]  create a button to trigger the saving of the first acquired volume
1.  - [x]  create a button to toggle the visualization of the volume on/off
1.  - [x]  trigger save of the first volume if button is selected -> reset first volume after
1.  - [x]  if button not selected then disable buttons during acquisition
1.  - [x]  test with a fish
1.  - [x]  write docstrings