### PR TITLE
WIP: Add trigger to planar mode

### DIFF
--- a/sashimi/hardware/cameras/hamamatsu/interface.py
+++ b/sashimi/hardware/cameras/hamamatsu/interface.py
@@ -242,7 +242,6 @@ class HamamatsuCamera(AbstractCamera):
     def set_property_value(self, property_name, property_value, *args, **kwargs):
         # Check if the property exists.
         if not (property_name in self.properties):
-
             raise CameraException(f"Unknown property name {property_name}")
 
         # If the value is text, figure out what the

--- a/sashimi/hardware/cameras/hamamatsu/sdk.py
+++ b/sashimi/hardware/cameras/hamamatsu/sdk.py
@@ -44,6 +44,7 @@ DCAMBUF_ATTACHKIND_FRAME = 0
 
 # Hamamatsu structures.
 
+
 ## DCAMAPI_INIT
 #
 # The dcam initialization structure

--- a/sashimi/hardware/scanning/scanloops.py
+++ b/sashimi/hardware/scanning/scanloops.py
@@ -111,7 +111,6 @@ class ScanLoop:
         logger: ConcurrenceLogger,
         trigger_exp_from_scanner,
     ):
-
         self.sample_rate = sample_rate
         self.n_samples = n_samples
 
@@ -286,7 +285,8 @@ class TriggeredPlanarScanLoop(ScanLoop):
 
     def loop_condition(self):
         return (
-            super().loop_condition() and self.parameters.state == ScanningState.TRIGGERED_PLANAR
+            super().loop_condition()
+            and self.parameters.state == ScanningState.TRIGGERED_PLANAR
         )
 
     def n_samples_period(self):
@@ -342,7 +342,9 @@ class TriggeredPlanarScanLoop(ScanLoop):
                 self.logger.log_message("Camera was off")
                 # calculate how many samples are remaining until we are in a new period
                 if self.i_sample == 0:
-                    camera_pulses = self.camera_pulses.read(self.i_sample, self.n_samples)
+                    camera_pulses = self.camera_pulses.read(
+                        self.i_sample, self.n_samples
+                    )
                     self.camera_was_off = False
                     self.wait_signal.clear()
                 else:

--- a/sashimi/processes/camera.py
+++ b/sashimi/processes/camera.py
@@ -178,7 +178,6 @@ class CameraProcess(LoggingProcess):
             # if no frames are received (either this loop is in between frames
             # or we are in the waining period)
             if frames:
-
                 for frame in frames:
                     self.logger.log_message(
                         "received frame of shape " + str(frame.shape)

--- a/sashimi/processes/scanning.py
+++ b/sashimi/processes/scanning.py
@@ -5,6 +5,7 @@ from sashimi.hardware.scanning.scanloops import (
     ScanningState,
     ScanParameters,
     PlanarScanLoop,
+    TriggeredPlanarScanLoop,
     VolumetricScanLoop,
 )
 from sashimi.hardware.scanning import ScanningError
@@ -96,6 +97,8 @@ class ScannerProcess(LoggingProcess):
             with configurator(self.sample_rate, self.n_samples, conf) as board:
                 if self.parameters.state == ScanningState.PLANAR:
                     loop = PlanarScanLoop
+                elif self.parameters.state == ScanningState.TRIGGERED_PLANAR:
+                    loop = TriggeredPlanarScanLoop
                 elif self.parameters.state == ScanningState.VOLUMETRIC:
                     loop = VolumetricScanLoop
 

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -275,7 +275,7 @@ def convert_single_plane_params(
     calibration: Calibration,
 ):
     return ScanParameters(
-        state=ScanningState.PLANAR,
+        state=ScanningState.TRIGGERED_PLANAR,
         xy=convert_planar_params(planar),
         z=ZSynced(
             piezo=single_plane_setting.piezo,
@@ -535,7 +535,6 @@ class State:
         camera_params.trigger_mode = (
             TriggerMode.FREE
             if self.global_state == GlobalState.PREVIEW
-            or self.global_state == GlobalState.PLANAR_PREVIEW
             else TriggerMode.EXTERNAL_TRIGGER
         )
         if self.global_state == GlobalState.PAUSED:

--- a/sashimi/state.py
+++ b/sashimi/state.py
@@ -228,7 +228,6 @@ def get_voxel_size(
     scanning_settings: Union[ZRecordingSettings, SinglePlaneSettings],
     camera_settings: CameraSettings,
 ):
-
     binning = int(camera_settings.binning)
 
     if isinstance(scanning_settings, SinglePlaneSettings):
@@ -668,7 +667,6 @@ class State:
         self.dispatcher.calibration_ref_queue.put(self.calibration_ref)
 
     def reset_noise_subtraction(self):
-
         self.calibration_ref = None
         self.noise_subtraction_active.clear()
 


### PR DESCRIPTION
Adds a trigger to planar mode such that the frame rate can be set explicitly. This is what you would expect given the GUI but not what was actually happening behind the scenes. This solves the third point in #144.

In principle this does away with the non-triggered planar mode, but as I understood it has not been useful so far because there was no reliable way of getting the timing of the frames (see #2). 

Since the basic functionality is working (feedback would be great!), I'm creating a PR, but the new class has to be reworked. Currently it is a merge between the old `PlanarScanLoop` and the `VolumetricScanLoop` without regard to what is the most maintainable/elegant way of writing. The main reason for this is that I do not fully understand the working of some parts of the code.